### PR TITLE
Expose lib as per-system output via transposition

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -11,6 +11,10 @@
         "aarch64-darwin"
       ];
 
+      transposition.lib = {
+        adHoc = true;
+      };
+
       perSystem =
         {
           pkgs,
@@ -18,6 +22,9 @@
           self',
           ...
         }:
+        let
+          florestaBuild = import ./lib/floresta-build.nix { inherit pkgs; };
+        in
         {
           _module.args.pkgs = import inputs.nixpkgs { inherit system; };
 
@@ -40,19 +47,17 @@
             };
           };
 
-          packages =
-            let
-              florestaBuild = import ./lib/floresta-build.nix { inherit pkgs; };
-            in
-            {
-              inherit (florestaBuild)
-                florestad
-                floresta-cli
-                libfloresta
-                floresta-debug
-                default
-                ;
-            };
+          lib = { inherit florestaBuild; };
+
+          packages = {
+            inherit (florestaBuild)
+              florestad
+              floresta-cli
+              libfloresta
+              floresta-debug
+              default
+              ;
+          };
 
           devShells.default = pkgs.mkShell {
             inherit (self'.checks.nix-sanity-check) shellHook;
@@ -62,13 +67,6 @@
             ];
           };
         };
-
-      flake = {
-        # Without defined pkgs
-        lib = {
-          florestaBuild = import ./lib/floresta-build.nix;
-        };
-      };
     };
 
   inputs = {


### PR DESCRIPTION
should fix #5.

## What changed

- Dropped the `flake = { lib = { ... }; }` block
- Added `transposition.lib = { adHoc = true; }` for per-system `lib`
- `florestaBuild` is now a single `let` binding in `perSystem`, shared by both `lib` and `packages`

### Before (consumer side)

```nix
floresta-nix.lib.florestaBuild { pkgs = import nixpkgs { inherit system; }; }
```

### After (consumer side)

```nix
floresta-nix.lib.${system}.florestaBuild
```

## How I tested

- `nix flake check` — all hooks pass (nil, nixfmt-rfc-style, statix, deadnix, flake-checker)
- `nix flake show` — `lib` shows up under each system
- `nix build .#florestad` — builds fine
- Tested as downstream consumer on my NixOS server, running florestad via `floresta-nix.lib.${system}.florestaBuild`
