### PR TITLE
chore: upgrade nixpkgs to nixos-26.05

### DIFF
--- a/examples/flake.lock
+++ b/examples/flake.lock
@@ -1,5 +1,27 @@
 {
   "nodes": {
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "floresta-nix",
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1786005881,
+        "narHash": "sha256-Bj3VKIiwX1daO4vOIyAM507A65J0aaRSctc87kiT7H4=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "a7c3ef79859bf024cdc865a0ed8f14a4e3f31099",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -21,11 +43,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1775087534,
-        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
+        "lastModified": 1785627969,
+        "narHash": "sha256-4dtXQk/NMePegK/nWp5NSeuZKLATItOq61lpEvmXqGw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
+        "rev": "427bf4bd9435fdf21321c8cc628c24efc14c0f7a",
         "type": "github"
       },
       "original": {
@@ -52,9 +74,28 @@
         "type": "github"
       }
     },
+    "floresta-master": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1786032823,
+        "narHash": "sha256-XYH0v+4Sefzbadh7qRgIUer2lX7UamH6JoAr8xS3qeA=",
+        "owner": "jaoleal",
+        "repo": "FlorestaBA",
+        "rev": "010fa00ba9cf37fea5bf851d68196653af7703a3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "jaoleal",
+        "ref": "android_patched_bitcoinkernel",
+        "repo": "FlorestaBA",
+        "type": "github"
+      }
+    },
     "floresta-nix": {
       "inputs": {
+        "fenix": "fenix",
         "flake-parts": "flake-parts",
+        "floresta-master": "floresta-master",
         "nixpkgs": "nixpkgs",
         "pre-commit-hooks": "pre-commit-hooks"
       },
@@ -68,51 +109,29 @@
       },
       "parent": []
     },
-    "gitignore": {
-      "inputs": {
-        "nixpkgs": [
-          "floresta-nix",
-          "pre-commit-hooks",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1709087332,
-        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1767313136,
-        "narHash": "sha256-16KkgfdYqjaeRGBaYsNrhPRRENs0qzkQVUooNHtoy2w=",
+        "lastModified": 1785989512,
+        "narHash": "sha256-HFQhkQcl5D1hUNoen3SGHCSFCt2Bg6uP+HgbrnA3InQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ac62194c3917d5f474c1a844b6fd6da2db95077d",
+        "rev": "445d861c6d31b4af0c79d8d4be2331f762a361d7",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.05",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1774748309,
-        "narHash": "sha256-+U7gF3qxzwD5TZuANzZPeJTZRHS29OFQgkQ2kiTJBIQ=",
+        "lastModified": 1785031560,
+        "narHash": "sha256-OmshNvn2vupOFpYinLUu+1Dnpu4n7Q5N3ggGVNHpkUI=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "333c4e0545a6da976206c74db8773a1645b5870a",
+        "rev": "0e79af5e3d4dcfcd676ab5ba3f95d2e3352e078c",
         "type": "github"
       },
       "original": {
@@ -123,11 +142,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1770073757,
-        "narHash": "sha256-Vy+G+F+3E/Tl+GMNgiHl9Pah2DgShmIUBJXmbiQPHbI=",
+        "lastModified": 1782918843,
+        "narHash": "sha256-ETYnV9U7Sr+A45dohzZdfCZKOss4qrTkO+wgNZNvEc0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "47472570b1e607482890801aeaf29bfb749884f6",
+        "rev": "e8273b29fe1390ec8d4603f2477357555291432e",
         "type": "github"
       },
       "original": {
@@ -139,16 +158,16 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1767313136,
-        "narHash": "sha256-16KkgfdYqjaeRGBaYsNrhPRRENs0qzkQVUooNHtoy2w=",
+        "lastModified": 1785989512,
+        "narHash": "sha256-HFQhkQcl5D1hUNoen3SGHCSFCt2Bg6uP+HgbrnA3InQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ac62194c3917d5f474c1a844b6fd6da2db95077d",
+        "rev": "445d861c6d31b4af0c79d8d4be2331f762a361d7",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.05",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -156,15 +175,14 @@
     "pre-commit-hooks": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "gitignore": "gitignore",
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1775585728,
-        "narHash": "sha256-8Psjt+TWvE4thRKktJsXfR6PA/fWWsZ04DVaY6PUhr4=",
+        "lastModified": 1784288435,
+        "narHash": "sha256-ReRHaLgr/uVqdD8afFSn+myXIfpHeOhP0yYe0TJqAA8=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "580633fa3fe5fc0379905986543fd7495481913d",
+        "rev": "43b3c1ab9d40fb1dbb008f451988a91e375825e9",
         "type": "github"
       },
       "original": {
@@ -178,6 +196,23 @@
         "flake-utils": "flake-utils",
         "floresta-nix": "floresta-nix",
         "nixpkgs": "nixpkgs_3"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1785960076,
+        "narHash": "sha256-+Xej+akyhjZIFnsEIZLO3c6YNvlnKB3rFMzsprQCyDM=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "cf3b451f47c01d76989425d1ace3f1cba70f1fdb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
       }
     },
     "systems": {

--- a/examples/flake.nix
+++ b/examples/flake.nix
@@ -5,7 +5,7 @@
 # Used in CI to verify the consumer integration interface.
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
     flake-utils.url = "github:numtide/flake-utils";
     floresta-nix.url = "path:../";
   };

--- a/flake.lock
+++ b/flake.lock
@@ -74,16 +74,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1767313136,
-        "narHash": "sha256-16KkgfdYqjaeRGBaYsNrhPRRENs0qzkQVUooNHtoy2w=",
+        "lastModified": 1785989512,
+        "narHash": "sha256-HFQhkQcl5D1hUNoen3SGHCSFCt2Bg6uP+HgbrnA3InQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ac62194c3917d5f474c1a844b6fd6da2db95077d",
+        "rev": "445d861c6d31b4af0c79d8d4be2331f762a361d7",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.05",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -67,7 +67,7 @@
               flakeInputs = inputs;
             };
           }
-          // pkgs.lib.optionalAttrs pkgs.hostPlatform.isLinux {
+          // pkgs.lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
             service-vm-test = import ./lib/floresta-service-vm-test.nix {
               inherit pkgs;
               flakeInputs = inputs;
@@ -151,7 +151,7 @@
             inherit (self'.checks.nix-sanity-check) shellHook;
             packages = with pkgs; [
               nil
-              nixfmt-classic
+              nixfmt
               just
               nix-output-monitor
               cachix
@@ -161,7 +161,7 @@
     };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
 
     flake-parts.url = "github:hercules-ci/flake-parts";
 

--- a/lib/floresta-build.nix
+++ b/lib/floresta-build.nix
@@ -192,14 +192,11 @@ let
       pkgConfig = packageConfigs.${cfg.packageName};
       cargoToml = builtins.fromTOML (builtins.readFile "${cfg.src}/${pkgConfig.cargoTomlPath}");
 
-      # Darwin frameworks linked into the target binary
-      darwinFrameworks =
-        with pkgs.darwin.apple_sdk.frameworks;
-        [
-          Security
-          SystemConfiguration
-        ]
-        ++ [ pkgs.libiconv ];
+      # Darwin libraries linked into the target binary.  The Security and
+      # SystemConfiguration frameworks used to be listed here explicitly;
+      # since the nixpkgs Darwin SDK rework they ship with the default
+      # `apple-sdk` that the Darwin stdenv already provides.
+      darwinInputs = [ pkgs.libiconv ];
 
       inherit (pkgs.stdenv) targetPlatform;
     in
@@ -221,14 +218,12 @@ let
         ]
         ++ lib.optionals pkgs.stdenv.buildPlatform.isDarwin [
           pkgs.buildPackages.libiconv
-          pkgs.buildPackages.darwin.apple_sdk.frameworks.Security
-          pkgs.buildPackages.darwin.apple_sdk.frameworks.SystemConfiguration
         ]
         ++ extraNativeBuildInputsGlobal
         ++ cfg.extraBuildInputs;
 
-        # Libraries and frameworks linked into the target binary
-        buildInputs = lib.optionals targetPlatform.isDarwin darwinFrameworks;
+        # Libraries linked into the target binary
+        buildInputs = lib.optionals targetPlatform.isDarwin darwinInputs;
 
         # Cargo.lock pins libbitcoinkernel-sys to a git rev, which carries no
         # checksum.  Let builtins.fetchGit vendor it from the pinned rev

--- a/lib/floresta-service-vm-test.nix
+++ b/lib/floresta-service-vm-test.nix
@@ -13,7 +13,7 @@ let
     sleep infinity
   '';
 
-  test = pkgs.nixosTest {
+  test = pkgs.testers.nixosTest {
     name = "floresta-service-vm-test";
 
     nodes.machine =


### PR DESCRIPTION
nixos-25.05 is frozen and out of support. Bump both the root flake and the example consumer flake to nixos-26.05, and fix the API breakage the jump exposes:

- darwin.apple_sdk.frameworks was removed as a legacy compatibility stub. Security and SystemConfiguration now ship with the default apple-sdk that the Darwin stdenv already provides, so the explicit references just go away; libiconv is kept.
- pkgs.nixosTest was renamed to pkgs.testers.nixosTest.
- pkgs.hostPlatform was renamed to pkgs.stdenv.hostPlatform.