### PR TITLE
feat: build the workspace as one package

### DIFF
--- a/lib/floresta-build.nix
+++ b/lib/floresta-build.nix
@@ -3,7 +3,14 @@
 {
   pkgs ? import <nixpkgs> { },
   lib ? pkgs.lib,
-  defaultSrc ? null,
+  # Source tree every build defaults to; standalone imports fall back to
+  # the latest release tag.
+  defaultSrc ? pkgs.fetchFromGitHub {
+    owner = "getfloresta";
+    repo = "Floresta";
+    rev = "v0.9.1";
+    hash = "sha256-5dfE0Bd0yCDh7Kc0PsSXjBWLQ9WmNCCbropdXfK9YSk=";
+  },
   # Extra environment variables set on buildRustPackage (e.g. ANDROID_NDK_HOME)
   extraEnvVars ? { },
   # Extra native build inputs added to every build (e.g. Android SDK)
@@ -20,6 +27,10 @@
   # pkgs.rustPlatform.  For Android cross-compilation a fenix-based
   # platform with the target's rust-std must be supplied.
   rustPlatform ? pkgs.rustPlatform,
+  # Appended to every package name produced by this import, to tell cross
+  # variants apart in the store: an Android import passes "-aarch64-android"
+  # and gets `floresta-aarch64-android`.
+  pnameSuffix ? "",
 }:
 
 let
@@ -34,7 +45,6 @@ let
           "libfloresta"
           "florestad"
           "floresta-cli"
-          "floresta-debug"
         ];
         default = "all";
         description = ''
@@ -44,28 +54,35 @@ let
           - `libfloresta`: Only the Floresta library
           - `florestad`: Only the Floresta Node
           - `floresta-cli`: Only the CLI tool
-          - `floresta-debug`: CLI and Node with Debug profile
         '';
         example = "florestad";
       };
 
+      profile = mkOption {
+        type = types.enum [
+          "release"
+          "debug"
+        ];
+        default = "release";
+        description = ''
+          Cargo profile to build with.
+
+          `debug` keeps assertions and debug info, at the cost of a much
+          slower binary.  Ignored by cross builds that drive cargo through a
+          custom build phase.
+        '';
+        example = "debug";
+      };
+
       src = mkOption {
         type = types.path;
-        default =
-          if defaultSrc != null then
-            defaultSrc
-          else
-            pkgs.fetchFromGitHub {
-              owner = "getfloresta";
-              repo = "Floresta";
-              rev = "v0.9.1";
-              hash = "sha256-5dfE0Bd0yCDh7Kc0PsSXjBWLQ9WmNCCbropdXfK9YSk=";
-            };
+        default = defaultSrc;
         description = ''
           Source tree for the Floresta project.
 
-          By default, fetches the latest master branch from GitHub.
-          Can be overridden to use a local checkout or specific revision.
+          Defaults to whatever the import was given as `defaultSrc` — the
+          latest release tag, for a standalone import. Can be overridden to
+          use a local checkout or specific revision.
         '';
         example = ''
           pkgs.fetchFromGitHub {
@@ -139,13 +156,16 @@ let
     in
     evaluated.config;
 
-  # Package-specific configurations
+  # Package-specific configurations.  `mainProgram` is the binary the package
+  # is run as, which is not the package name for the workspace build: it
+  # installs florestad and floresta-cli, and nothing called floresta.
   packageConfigs = {
     all = {
       pname = "floresta";
       cargoBuildFlags = [ ];
-      description = "Floresta packages, CLI and Node";
+      description = "Floresta node, CLI and library";
       cargoTomlPath = "bin/florestad/Cargo.toml";
+      mainProgram = "florestad";
     };
 
     libfloresta = {
@@ -153,6 +173,7 @@ let
       cargoBuildFlags = [ "--lib" ];
       description = "Floresta library";
       cargoTomlPath = "crates/floresta/Cargo.toml";
+      mainProgram = null;
     };
 
     florestad = {
@@ -163,6 +184,7 @@ let
       ];
       description = "Floresta Node";
       cargoTomlPath = "bin/florestad/Cargo.toml";
+      mainProgram = "florestad";
     };
 
     floresta-cli = {
@@ -173,14 +195,7 @@ let
       ];
       description = "Floresta CLI";
       cargoTomlPath = "bin/floresta-cli/Cargo.toml";
-    };
-
-    floresta-debug = {
-      pname = "floresta-debug";
-      cargoBuildFlags = [ ];
-      description = "Floresta in debug profile";
-      cargoTomlPath = "bin/florestad/Cargo.toml";
-      extraFeatures = [ "metrics" ];
+      mainProgram = "floresta-cli";
     };
   };
 
@@ -203,10 +218,16 @@ let
     rustPlatform.buildRustPackage (
       {
         inherit (cargoToml.package) version;
-        inherit (pkgConfig) pname description cargoBuildFlags;
+        inherit (pkgConfig) description cargoBuildFlags;
         inherit (cfg) src doCheck;
 
-        buildFeatures = cfg.features ++ (cfg.extraFeatures or [ ]);
+        # The profile is part of the name: a debug build of a release is a
+        # different derivation of the same version, and two store paths that
+        # differ only by a hash are not worth telling apart by hand.
+        pname =
+          pkgConfig.pname + pnameSuffix + lib.optionalString (cfg.profile != "release") "-${cfg.profile}";
+        buildType = cfg.profile;
+        buildFeatures = cfg.features;
 
         # Build-time tools that run on the build machine
         nativeBuildInputs = [
@@ -216,9 +237,7 @@ let
           pkgs.buildPackages.llvmPackages.clang
           pkgs.buildPackages.llvmPackages.libclang
         ]
-        ++ lib.optionals pkgs.stdenv.buildPlatform.isDarwin [
-          pkgs.buildPackages.libiconv
-        ]
+        ++ lib.optionals pkgs.stdenv.buildPlatform.isDarwin [ pkgs.buildPackages.libiconv ]
         ++ extraNativeBuildInputsGlobal
         ++ cfg.extraBuildInputs;
 
@@ -285,17 +304,20 @@ let
           "--skip=p2p_wire::node::conn::tests::test_parse_address"
         ];
 
-        meta = with lib; {
-          description = "A lightweight bitcoin full node - ${pkgConfig.description}";
-          homepage = "https://github.com/getfloresta/Floresta";
-          license = with licenses; [
-            mit
-            asl20
-          ];
-          maintainers = with maintainers; [ jaoleal ];
-          platforms = platforms.unix;
-          mainProgram = pkgConfig.pname;
-        };
+        meta =
+          with lib;
+          {
+            description = "A lightweight bitcoin full node - ${pkgConfig.description}";
+            homepage = "https://github.com/getfloresta/Floresta";
+            license = with licenses; [
+              mit
+              asl20
+            ];
+            maintainers = with maintainers; [ jaoleal ];
+            platforms = platforms.unix;
+          }
+          # A library has no binary to be run as.
+          // lib.optionalAttrs (pkgConfig.mainProgram != null) { inherit (pkgConfig) mainProgram; };
 
         passthru = {
           inherit cfg pkgConfig;
@@ -310,9 +332,24 @@ in
 {
   inherit mkFloresta buildFlorestaOptions;
 
+  # Everything a Floresta build publishes, from one compile of the workspace:
+  # `cargo build` over the default members leaves the binaries and the cdylib
+  # /staticlib targets in one directory, and the install hook sorts them into
+  # bin/ and lib/. Nothing here lists what that is — the source tree decides,
+  # and the version comes off the Cargo.toml being built.
+  #
+  # Three `--bin`/`--lib` builds joined afterwards would name the same files
+  # and compile the shared dependency graph — libbitcoinkernel included —
+  # once each.
   default = mkFloresta { };
+
+  debug = mkFloresta { profile = "debug"; };
+
   florestad = mkFloresta { packageName = "florestad"; };
   floresta-cli = mkFloresta { packageName = "floresta-cli"; };
   libfloresta = mkFloresta { packageName = "libfloresta"; };
-  floresta-debug = mkFloresta { packageName = "floresta-debug"; };
+  floresta-debug = mkFloresta {
+    profile = "debug";
+    features = [ "metrics" ];
+  };
 }


### PR DESCRIPTION
The build library exports default/debug workspace builds; the profile joins the package name, meta carries mainProgram, and a standalone import falls back to the latest release tag as its source. The per-component exports stay as a compat layer for the current flake and android-outputs, to be dropped when packages become releases.